### PR TITLE
Dostrings handling (Issue #1)

### DIFF
--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -1,0 +1,33 @@
+from .tests import assert_decompiles
+
+
+def test_module_docstring():
+    assert_decompiles('''
+"""
+module docstring
+"""
+
+
+class A():
+    """
+    class docstring
+    """
+    def b():
+        """
+        function docstring
+        """
+''', '''
+"""
+module docstring
+"""
+
+
+class A():
+ """
+ class docstring
+ """
+ def b():
+  """
+  function docstring
+  """
+''', indentation=1)


### PR DESCRIPTION
Implemented docstring handling for module-, class- and function-level docstrings.

It works alright, but the test fails. The `tests.check()` function expects ASTs before and after decompilation to be completely identical, but this is not the case. Maybe there is a way to ignore some differences in Str-nodes while comparing ASTs? Or maybe we should preprocess nodes before comparison, so that unnecessary whitespace in docstrings is gone?

![result](https://cloud.githubusercontent.com/assets/10929676/23353604/ac43e5cc-fce6-11e6-9df9-9c59f8979db7.png)

Semantically they are the same. The difference is (and it's expected):
```
- Expr(value=Str(s='\n    class docstring\n    ')),
+ Expr(value=Str(s='\n class docstring\n ')),
```