### PR TITLE
Fix Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ python:
 install:
   - pip install -r test_requirements.txt
 
-script: python -m nose tests/
+script: py.test

--- a/README.rst
+++ b/README.rst
@@ -12,4 +12,4 @@ A usage example::
     >> decompile(ast.parse('(a + b) * c'))
     (a + b) * c
 
-This module has been tested on Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+This module has been tested on Python 2.7, 3.3, 3.4, 3.5, 3.6, 3.7 and 3.8.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,1 @@
-nose
+pytest


### PR DESCRIPTION
Thanks so much for the great package! It's really useful to me for the tests in [fluent-compiler](https://github.com/django-ftl/fluent-compiler).

This PR fixes support for Python 3.8. All tests pass, and I tested on all versions back to Python 3.3 and nothing seems to be broken. Hopefully Travis will confirm this,

Due to problems trying to run tests, I also went ahead and switched from nose to py.test for running tests, in a separate commit - see commit message.  If that's not OK let me know I'll make a separate PR.

I also updated the Travis matrix so that tests are run on Python 3.7 and 3.8

