### PR TITLE
Fix decompilation of subscripts on Python <3.9

### DIFF
--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -957,7 +957,7 @@ class Decompiler(ast.NodeVisitor):
             allow_parens = True
             should_parenthesize = not isinstance(
                 parent_node,
-                (ast.Expr, ast.Assign, ast.AugAssign, ast.Return, ast.Yield),
+                (ast.Expr, ast.Assign, ast.AugAssign, ast.Return, ast.Yield, ast.Index),
             )
             if (
                 isinstance(parent_node, ast.comprehension)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -412,6 +412,7 @@ def test_Subscript() -> None:
     check("(-0j)[y]")
     check("x[y]")
     check("Callable[[P, Iterator], T]")
+    assert decompile(ast.parse("Union[str, int]")) == "Union[str, int]\n"
 
 
 def test_Name() -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -412,7 +412,7 @@ def test_Subscript() -> None:
     check("(-0j)[y]")
     check("x[y]")
     check("Callable[[P, Iterator], T]")
-    assert decompile(ast.parse("Union[str, int]")) == "Union[str, int]\n"
+    assert_decompiles("Union[str, int]", "Union[str, int]\n")
 
 
 def test_Name() -> None:


### PR DESCRIPTION
Fixes #40 (I think)