### PR TITLE
Make decompilation of complex numbers match `ast.unparse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+unreleased
+- Stop adding redundant parentheses to `complex` numbers with no real part and a negative
+  imaginary part (thanks to Alex Waygood)
+
 version 0.6.0 (June 6, 2022)
 - Support Python 3.11
 - Fix bug where annotations on `*args` and `**kwargs` were dropped

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -792,13 +792,6 @@ class Decompiler(ast.NodeVisitor):
                 and number.real == 0.0
                 and (number.imag < 0 or number.imag == -0.0)
             )
-        if not should_parenthesize and (isinstance(number, complex) or number < 0):
-            parent_node = self.get_parent_node()
-            should_parenthesize = (
-                isinstance(parent_node, ast.UnaryOp)
-                and isinstance(parent_node.op, ast.USub)
-                and hasattr(parent_node, "lineno")
-            )
         with self.parenthesize_if(should_parenthesize):
             if isinstance(number, float) and math.isinf(number):
                 # otherwise we write inf, which won't be parsed back right
@@ -990,7 +983,6 @@ class Decompiler(ast.NodeVisitor):
             self.visit(node.step)
 
     if sys.version_info < (3, 9):
-
         # Any to avoid version-dependent errors from pyanalyze.
         def visit_ExtSlice(self, node: Any) -> None:
             if len(node.dims) == 1:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -368,6 +368,7 @@ def test_Num() -> None:
     assert_decompiles("-3j", "-3j\n")
     assert_decompiles("1 + 3j", "1 + 3j\n")
     assert_decompiles("-1-42j", "-1 - 42j\n")
+    assert_decompiles("-(1-42j)", "-(1 - 42j)\n")
 
 
 @only_on_version(2)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -362,6 +362,12 @@ def test_Num() -> None:
     check("1E+12_7_3J")
     check("-1E+12_7_3J")
     check("-(1)")
+    assert_decompiles("-42", "-42\n")
+    assert_decompiles("-42.35", "-42.35\n")
+    assert_decompiles("3j", "3j\n")
+    assert_decompiles("-3j", "-3j\n")
+    assert_decompiles("1 + 3j", "1 + 3j\n")
+    assert_decompiles("-1-42j", "-1 - 42j\n")
 
 
 @only_on_version(2)


### PR DESCRIPTION
Currently:

```pycon
>>> from ast import parse, unparse
>>> from ast_decompiler import decompile
>>> unparse(parse('-3j'))
'-3j'
>>> decompile(parse('-3j'))
'-(3j)\n'
```

This PR fixes the discrepancy with respect to the parentheses.

This fix feels a little too "dumb" -- I'm not sure I fully understand the purpose of the block of code I'm deleting. But all the tests seem to pass locally :)