### PR TITLE
Support Python 3.15 syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]
 
     steps:
     - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 Unreleased
+- Support Python 3.15
 - Support Python 3.14; stop testing Python 3.8
 
 version 0.8.0 (May 17, 2024)

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ A usage example::
     >> decompile(ast.parse('(a + b) * c'))
     (a + b) * c
 
-This module supports Python 3.9 through 3.14.
+This module supports Python 3.9 through 3.15.
 
 ====================
 Tests and formatting

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -349,7 +349,7 @@ class Decompiler(ast.NodeVisitor):
             self.write_expression_list(node.type_params)
             self.write("]")
         self.write("(")
-        exprs = node.bases + getattr(node, "keywords", [])
+        exprs = node.bases + node.keywords
         self.write_expression_list(exprs, need_parens=False)
         self.write("):")
         self.write_newline()
@@ -548,6 +548,8 @@ class Decompiler(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import) -> None:
         self.write_indentation()
+        if sys.version_info >= (3, 15) and node.is_lazy:
+            self.write("lazy ")
         self.write("import ")
         self.write_expression_list(node.names, allow_newlines=False)
         self.write_newline()
@@ -555,6 +557,8 @@ class Decompiler(ast.NodeVisitor):
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         self.write_indentation()
         dots = "." * (node.level or 0)
+        if sys.version_info >= (3, 15) and node.is_lazy:
+            self.write("lazy ")
         self.write(f"from {dots}")
         if node.module:
             self.write(node.module)
@@ -704,11 +708,16 @@ class Decompiler(ast.NodeVisitor):
 
     def visit_KeyValuePair(self, node: KeyValuePair) -> None:
         if node.key is None:
-            self.write("**")
+            self.write_double_starred(node.value)
         else:
             self.visit(node.key)
             self.write(": ")
-        self.visit(node.value)
+            self.visit(node.value)
+
+    def write_double_starred(self, node: ast.AST) -> None:
+        self.write("**")
+        with self.parenthesize_if(isinstance(node, ast.IfExp)):
+            self.visit(node)
 
     def visit_Set(self, node: ast.Set) -> None:
         self.write("{")
@@ -723,7 +732,10 @@ class Decompiler(ast.NodeVisitor):
 
     def visit_DictComp(self, node: ast.DictComp) -> None:
         self.write("{")
-        elts = [KeyValuePair(node.key, node.value)] + node.generators
+        if sys.version_info >= (3, 15) and node.value is None:
+            elts = [KeyValuePair(None, node.key)] + node.generators
+        else:
+            elts = [KeyValuePair(node.key, node.value)] + node.generators
         self.write_expression_list(elts, separator=" ", need_parens=False)
         self.write("}")
 
@@ -1008,9 +1020,9 @@ class Decompiler(ast.NodeVisitor):
         self.write("]")
 
     def visit_Starred(self, node: ast.Starred) -> None:
-        # TODO precedence
         self.write("*")
-        self.visit(node.value)
+        with self.parenthesize_if(isinstance(node.value, ast.IfExp)):
+            self.visit(node.value)
 
     def visit_Name(self, node: ast.Name) -> None:
         self.write(node.id)
@@ -1175,10 +1187,10 @@ class Decompiler(ast.NodeVisitor):
     def visit_keyword(self, node: ast.keyword) -> None:
         if node.arg is None:
             # in py3, **kwargs is a keyword whose arg is None
-            self.write("**")
+            self.write_double_starred(node.value)
         else:
             self.write(node.arg + "=")
-        self.visit(node.value)
+            self.visit(node.value)
 
     def visit_alias(self, node: ast.alias) -> None:
         self.write(node.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development",
 ]
 

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -395,3 +395,39 @@ except* ValueError, TypeError:
     pass
 """
     )
+
+
+@skip_before((3, 15))
+def test_lazy_imports() -> None:
+    check("lazy import json")
+    check("lazy import json as js, os.path")
+    check("lazy from json import dumps, loads as l")
+    check("lazy from . import sibling")
+    check("lazy from ..pkg import item as alias")
+
+
+@skip_before((3, 15))
+def test_unpacking_comprehensions() -> None:
+    check("[*it for it in its]")
+    check("[*(x if x else y) for x in xs]")
+    check("[*item for row in rows if row for item in row]")
+    check("{*it for it in its}")
+    check("{*(x if x else y) for x in xs}")
+    check("{**d for d in dicts}")
+    check("{**(x if x else y) for x in xs}")
+    check("(*it for it in its)")
+    check("(*(y := [i, i + 1]) for i in its)")
+    check("f(*it for it in its)")
+
+
+@skip_before((3, 15))
+def test_async_unpacking_comprehensions() -> None:
+    check(
+        """
+async def f(xs):
+    a = [*x async for x in xs]
+    b = {*x async for x in xs}
+    c = {**x async for x in xs}
+    d = (*x async for x in xs)
+"""
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.3.1
-envlist = py39,py310,py311,py312,py313,py314,black
+envlist = py39,py310,py311,py312,py313,py314,py315,black
 isolated_build = True
 
 [testenv]
@@ -46,3 +46,4 @@ python =
     3.12: py312, pyanalyze
     3.13: py313, black
     3.14: py314
+    3.15-dev: py315


### PR DESCRIPTION
## Summary

Add support for the Python 3.15 AST syntax additions:

- emit `lazy` for explicit lazy imports from PEP 810
- emit unpacking forms in comprehensions from PEP 798, including `*` list/set/generator expressions and `**` dict comprehensions
- expand the Python 3.15 test matrix and documentation metadata

The new coverage exercises lazy imports, relative lazy imports, starred and double-starred comprehension heads, async unpacking comprehensions, generator expression edge cases, and parenthesized conditional unpacking expressions.