### PR TITLE
fix pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,14 @@ version = "0.8.0"
 description = "Python module to decompile AST to Python code"
 readme = "README.rst"
 requires-python = ">=3.9"
-urls.Home = "https://github.com/JelleZijlstra/ast_decompiler"
-license.file = "LICENSE"
+urls.Homepage = "https://github.com/JelleZijlstra/ast_decompiler"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["ast", "decompiler"]
 # Classifiers list: https://pypi.org/classifiers/
 classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Python Software Foundation License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
At the moment pip 26.1.1 does not show home-page and license of ast_decompiler installed from PyPI or 37af7944da0dd7a214fc583b821c302ed7d087c1, while it works on PyPI:

```console
$ pip show 
Name: ast_decompiler
Version: 0.8.0
Summary: Python module to decompile AST to Python code
Home-page: 
Author: 
Author-email: Jelle Zijlstra <jelle.zijlstra@gmail.com>
License: 
Location: /tmp/tmp.f7qikUlAUZ/lib/python3.14/site-packages
Requires: 
Required-by: 
```

With applying this patch, info is modified as follows:

```diff
@@ -4 +4 @@
-Home-page: 
+Home-page: https://github.com/JelleZijlstra/ast_decompiler
@@ -7 +7 @@
-License: 
+License-Expression: Apache-2.0 OR PSF-2.0
```

The license classifier of pyproject specifies PSF, whereas the LICENSE file is Apache; I am not sure whether this means “Apache *AND* PSF” or “Apache *OR* PSF.” [PyPI](https://pypi.org/project/ast-decompiler/) shows PSF only.