### PR TITLE
codex fixes for pysource codegen

### DIFF
--- a/ast_decompiler/check.py
+++ b/ast_decompiler/check.py
@@ -3,10 +3,12 @@ from ast_decompiler import decompile
 import difflib
 
 
-def check(code: str) -> None:
+def check(code: str, line_length=100) -> None:
     """Checks that the code remains the same when decompiled and re-parsed."""
     tree = ast.parse(code)
-    new_code = decompile(tree)
+
+    new_code = decompile(tree, line_length=line_length)
+
     try:
         new_tree = ast.parse(new_code)
     except SyntaxError as e:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -656,7 +656,13 @@ class Decompiler(ast.NodeVisitor):
         )
         with self.parenthesize_if(should_parenthesize):
             self.write("lambda")
-            if node.args.args or node.args.vararg or node.args.kwarg:
+            if (
+                node.args.posonlyargs
+                or node.args.args
+                or node.args.vararg
+                or node.args.kwonlyargs
+                or node.args.kwarg
+            ):
                 self.write(" ")
             self.visit(node.args)
             self.write(": ")

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -907,6 +907,8 @@ class Decompiler(ast.NodeVisitor):
             if add_space:
                 self.write(" ")
             self.visit(node.value)
+            if add_space:
+                self.write(" ")
             if node.conversion != -1:
                 self.write(f"!{chr(node.conversion)}")
             if node.format_spec is not None:
@@ -921,8 +923,6 @@ class Decompiler(ast.NodeVisitor):
                     raise TypeError(
                         f"format spec must be a string, not {node.format_spec}"
                     )
-            if add_space:
-                self.write(" ")
             self.write("}")
 
     def visit_JoinedStr(self, node: ast.JoinedStr) -> None:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -318,7 +318,7 @@ class Decompiler(ast.NodeVisitor):
         self.write(f"def {node.name}")
         if sys.version_info >= (3, 12) and node.type_params:
             self.write("[")
-            self.write_expression_list(node.type_params)
+            self.write_expression_list(node.type_params, need_parens=False)
             self.write("]")
         self.write("(")
         self.visit(node.args)
@@ -346,7 +346,7 @@ class Decompiler(ast.NodeVisitor):
         self.write(f"class {node.name}")
         if sys.version_info >= (3, 12) and node.type_params:
             self.write("[")
-            self.write_expression_list(node.type_params)
+            self.write_expression_list(node.type_params, need_parens=False)
             self.write("]")
         self.write("(")
         exprs = node.bases + node.keywords
@@ -483,7 +483,7 @@ class Decompiler(ast.NodeVisitor):
             self.visit(node.name)
             if node.type_params:
                 self.write("[")
-                self.write_expression_list(node.type_params)
+                self.write_expression_list(node.type_params, need_parens=False)
                 self.write("]")
             self.write(" = ")
             self.visit(node.value)

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1278,7 +1278,7 @@ class Decompiler(ast.NodeVisitor):
         with self.parenthesize_if(isinstance(parent_node, ast.MatchOr)):
             self.write_expression_list(
                 node.patterns,
-                need_parens=False,
+                need_parens=True,
                 separator=" | ",
                 final_separator_if_multiline=False,
             )

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1138,19 +1138,18 @@ class Decompiler(ast.NodeVisitor):
 
     def visit_arguments(self, node: ast.arguments) -> None:
         args = []
-        if node.posonlyargs:
-            args += node.posonlyargs
-            args.append(ast.Name(id="/", ctx=ast.Load()))
-
+        positional_args = [*node.posonlyargs, *node.args]
         num_defaults = len(node.defaults)
-        if num_defaults:
-            args += node.args[:-num_defaults]
-            default_args = zip(node.args[-num_defaults:], node.defaults)
-        else:
-            args += list(node.args)
-            default_args = []
-        for name, value in default_args:
-            args.append(KeywordArg(name, value))
+        first_default = len(positional_args) - num_defaults
+        for index, arg in enumerate(positional_args):
+            if node.posonlyargs and index == len(node.posonlyargs):
+                args.append(ast.Name(id="/", ctx=ast.Load()))
+            if index >= first_default:
+                args.append(KeywordArg(arg, node.defaults[index - first_default]))
+            else:
+                args.append(arg)
+        if node.posonlyargs and not node.args:
+            args.append(ast.Name(id="/", ctx=ast.Load()))
 
         if node.vararg:
             args.append(StarArg(node.vararg))

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1107,7 +1107,8 @@ class Decompiler(ast.NodeVisitor):
         self.write("for ")
         self.visit(node.target)
         self.write(" in ")
-        self.visit(node.iter)
+        with self.parenthesize_if(isinstance(node.iter, ast.Lambda)):
+            self.visit(node.iter)
         for expr in node.ifs:
             self.write(" if ")
             self.visit(expr)

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -913,7 +913,8 @@ class Decompiler(ast.NodeVisitor):
             )
             if add_space:
                 self.write(" ")
-            self.visit(node.value)
+            with self.parenthesize_if(isinstance(node.value, ast.Lambda)):
+                self.visit(node.value)
             if add_space:
                 self.write(" ")
             if node.conversion != -1:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1250,13 +1250,14 @@ class Decompiler(ast.NodeVisitor):
     def visit_MatchClass(self, node: "ast.MatchClass") -> None:
         self.visit(node.cls)
         self.write("(")
-        self.write_expression_list(node.patterns, need_parens=False)
-        for i, (attr, pattern) in enumerate(zip(node.kwd_attrs, node.kwd_patterns)):
-            if i > 0 or node.patterns:
-                self.write(", ")
-            self.write(attr)
-            self.write("=")
-            self.visit(pattern)
+        patterns = [
+            *node.patterns,
+            *(
+                KeywordArg(ast.arg(arg=attr), pattern)
+                for attr, pattern in zip(node.kwd_attrs, node.kwd_patterns)
+            ),
+        ]
+        self.write_expression_list(patterns, need_parens=False)
         self.write(")")
 
     def visit_MatchAs(self, node: "ast.MatchAs") -> None:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1239,7 +1239,9 @@ class Decompiler(ast.NodeVisitor):
         items = [
             KeyValuePair(key, value) for key, value in zip(node.keys, node.patterns)
         ]
-        self.write_expression_list(items, need_parens=False)
+        self.write_expression_list(
+            items, need_parens=False, final_separator_if_multiline=node.rest is None
+        )
         if node.rest is not None:
             if node.keys:
                 self.write(", ")

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -778,7 +778,8 @@ class Decompiler(ast.NodeVisitor):
             )
         ):
             self.write("await ")
-            self.visit(node.value)
+            with self.parenthesize_if(isinstance(node.value, ast.IfExp)):
+                self.visit(node.value)
 
     def visit_Yield(self, node: ast.Yield) -> None:
         with self.parenthesize_if(

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1271,7 +1271,10 @@ class Decompiler(ast.NodeVisitor):
         parent_node = self.get_parent_node()
         with self.parenthesize_if(isinstance(parent_node, ast.MatchOr)):
             self.write_expression_list(
-                node.patterns, need_parens=False, separator=" | "
+                node.patterns,
+                need_parens=False,
+                separator=" | ",
+                final_separator_if_multiline=False,
             )
 
     def visit_MatchStar(self, node: "ast.MatchStar") -> None:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -1027,7 +1027,7 @@ class Decompiler(ast.NodeVisitor):
 
     def visit_Starred(self, node: ast.Starred) -> None:
         self.write("*")
-        with self.parenthesize_if(isinstance(node.value, ast.IfExp)):
+        with self.parenthesize_if(isinstance(node.value, (ast.Compare, ast.IfExp))):
             self.visit(node.value)
 
     def visit_Name(self, node: ast.Name) -> None:

--- a/ast_decompiler/decompiler.py
+++ b/ast_decompiler/decompiler.py
@@ -716,7 +716,7 @@ class Decompiler(ast.NodeVisitor):
 
     def write_double_starred(self, node: ast.AST) -> None:
         self.write("**")
-        with self.parenthesize_if(isinstance(node, ast.IfExp)):
+        with self.parenthesize_if(isinstance(node, (ast.IfExp, ast.Lambda))):
             self.visit(node)
 
     def visit_Set(self, node: ast.Set) -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -38,6 +38,7 @@ class Bar(object):
     check("class Bar: pass")
     check("class Bar(object): pass")
     check("class Bar(int, str): pass")
+    check("class Bar(**(lambda: attrs)): pass")
 
 
 def test_Return() -> None:
@@ -315,6 +316,7 @@ def test_Call() -> None:
     check("f()")
     check("f(1)")
     check("f(1, x=2)")
+    check("f(**(lambda: kwargs))")
     check("f(*args, **kwargs)")
     check("f(foo, *args, **kwargs)")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -251,6 +251,8 @@ def test_UnaryOp() -> None:
 def test_Lambda() -> None:
     check("lambda: None")
     check("lambda x: None")
+    check("lambda x, /: None")
+    check("lambda *, x: None")
     check("lambda x: x ** x")
     check("[x for x in y if (lambda: x)]")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -252,6 +252,8 @@ def test_Lambda() -> None:
     check("lambda: None")
     check("lambda x: None")
     check("lambda x, /: None")
+    check("lambda x=0, /: None")
+    check("lambda x, /, y=0: None")
     check("lambda *, x: None")
     check("lambda x: x ** x")
     check("[x for x in y if (lambda: x)]")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,6 @@
 import ast
 from ast_decompiler import decompile
-from .tests import assert_decompiles, check
+from .tests import assert_decompiles, check, skip_before
 
 
 def test_non_module() -> None:
@@ -280,6 +280,25 @@ def test_ListComp() -> None:
     check("[x for x in y if z]")
     check("[x for x in y for z in a]")
     check("[x for x in (lambda: y)]")
+
+
+@skip_before((3, 10))
+def test_MatchClass_multiline_positional_and_keyword_patterns() -> None:
+    assert_decompiles(
+        """
+match 0:
+    case C(A() | B() | D() | 'xt' | 'some const text', name=[]):
+        pass
+""",
+        """match 0:
+    case C(
+        A() | B() | D() | 'xt' | 'some const text',
+        name=[],
+    ):
+        pass
+""",
+        line_length=50,
+    )
     assert "[a for a, b in x]\n" == decompile(ast.parse("[a for a, b in x]"))
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -274,6 +274,7 @@ def test_ListComp() -> None:
     check("[x for x in y]")
     check("[x for x in y if z]")
     check("[x for x in y for z in a]")
+    check("[x for x in (lambda: y)]")
     assert "[a for a, b in x]\n" == decompile(ast.parse("[a for a, b in x]"))
 
 
@@ -293,6 +294,7 @@ def test_GeneratorExp() -> None:
     check("(x for x in y)")
     check("(x for x in y if z)")
     check("(x for x in y for z in a)")
+    check("(x for x in (lambda: y))")
     check("f(x for x in y)")
     assert "f(x for x in y)\n" == decompile(ast.parse("f(x for x in y)"))
 

--- a/tests/test_patma.py
+++ b/tests/test_patma.py
@@ -1,7 +1,5 @@
 import ast
 
-from ast_decompiler import decompile
-
 from .tests import check, skip_before
 
 
@@ -57,21 +55,22 @@ match x:
 
 @skip_before((3, 10))
 def test_multiline_match_or() -> None:
-    source = """
+    check(
+        """
 match x:
     case b"aaaaaaaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbbbbbbbbb":
         pass
     case a(y=(b"aaaaaaaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbbbbbbbbb")):
         pass
-"""
-    decompiled = decompile(ast.parse(source), line_length=40)
-
-    ast.parse(decompiled)
+""",
+        line_length=40,
+    )
 
 
 @skip_before((3, 10))
 def test_multiline_match_mapping_with_rest() -> None:
-    source = """
+    check(
+        """
 match x:
     case {
         b"aaaaaaaaaaaaaaaaaaaaaaaa": first,
@@ -79,7 +78,6 @@ match x:
         **rest,
     }:
         pass
-"""
-    decompiled = decompile(ast.parse(source), line_length=40)
-
-    ast.parse(decompiled)
+""",
+        line_length=40,
+    )

--- a/tests/test_patma.py
+++ b/tests/test_patma.py
@@ -1,3 +1,7 @@
+import ast
+
+from ast_decompiler import decompile
+
 from .tests import check, skip_before
 
 
@@ -49,3 +53,15 @@ match x:
         pass
 """
     )
+
+
+@skip_before((3, 10))
+def test_multiline_match_or() -> None:
+    source = """
+match x:
+    case a(y=(b"aaaaaaaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbbbbbbbbb")):
+        pass
+"""
+    decompiled = decompile(ast.parse(source), line_length=40)
+
+    ast.parse(decompiled)

--- a/tests/test_patma.py
+++ b/tests/test_patma.py
@@ -59,6 +59,8 @@ match x:
 def test_multiline_match_or() -> None:
     source = """
 match x:
+    case b"aaaaaaaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbbbbbbbbb":
+        pass
     case a(y=(b"aaaaaaaaaaaaaaaaaaaaaaaa" | "bbbbbbbbbbbbbbbbbbbbbbbb")):
         pass
 """

--- a/tests/test_patma.py
+++ b/tests/test_patma.py
@@ -67,3 +67,19 @@ match x:
     decompiled = decompile(ast.parse(source), line_length=40)
 
     ast.parse(decompiled)
+
+
+@skip_before((3, 10))
+def test_multiline_match_mapping_with_rest() -> None:
+    source = """
+match x:
+    case {
+        b"aaaaaaaaaaaaaaaaaaaaaaaa": first,
+        b"bbbbbbbbbbbbbbbbbbbbbbbb": second,
+        **rest,
+    }:
+        pass
+"""
+    decompiled = decompile(ast.parse(source), line_length=40)
+
+    ast.parse(decompiled)

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -37,7 +37,8 @@ type Y[T: (int, str), *Ts, *P] = T
 
 @skip_before((3, 12))
 def test_multiline_type_params() -> None:
-    source = """
+    check(
+        """
 def f[LongName: int, *LongTuple, **LongParams]() -> None:
     pass
 
@@ -45,10 +46,9 @@ class C[LongName: int, *LongTuple, **LongParams]:
     pass
 
 type Alias[LongName: int, *LongTuple, **LongParams] = LongName
-"""
-    decompiled = decompile(ast.parse(source), line_length=20)
-
-    ast.parse(decompiled)
+""",
+        line_length=20,
+    )
 
 
 @skip_before((3, 13))

--- a/tests/test_pep695.py
+++ b/tests/test_pep695.py
@@ -1,3 +1,7 @@
+import ast
+
+from ast_decompiler import decompile
+
 from .tests import check, skip_before
 
 
@@ -29,6 +33,22 @@ type X = int
 type Y[T: (int, str), *Ts, *P] = T
 """
     )
+
+
+@skip_before((3, 12))
+def test_multiline_type_params() -> None:
+    source = """
+def f[LongName: int, *LongTuple, **LongParams]() -> None:
+    pass
+
+class C[LongName: int, *LongTuple, **LongParams]:
+    pass
+
+type Alias[LongName: int, *LongTuple, **LongParams] = LongName
+"""
+    decompiled = decompile(ast.parse(source), line_length=20)
+
+    ast.parse(decompiled)
 
 
 @skip_before((3, 13))

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -205,6 +205,7 @@ def test_FormattedValue() -> None:
     check("f'{ {a: b} }'")
     check("f'{ {a for a in b} }'")
     check("f'{ {a: b for a, b in c} }'")
+    check("f'{(lambda: 0)}'")
     check(r"f'{a}\n'")
     check(r"f'{a}\t'")
     check("f'{a}é'")

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -243,6 +243,28 @@ def test_NameConstant() -> None:
 def test_Starred() -> None:
     check("a, *b = 3")
     check("[a, *b]")
+    tree = ast.Module(
+        body=[
+            ast.Expr(
+                value=ast.Tuple(
+                    elts=[
+                        ast.Starred(
+                            value=ast.Compare(
+                                left=ast.Constant(value=0),
+                                ops=[ast.LtE()],
+                                comparators=[ast.Constant(value=0)],
+                            ),
+                            ctx=ast.Load(),
+                        )
+                    ],
+                    ctx=ast.Load(),
+                )
+            )
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(tree)
+    assert ast.dump(ast.parse(decompile(tree))) == ast.dump(tree)
 
 
 def test_kwonlyargs() -> None:

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -2,7 +2,7 @@ import ast
 
 from ast_decompiler import decompile
 
-from .tests import check, skip_after, skip_before
+from .tests import assert_decompiles, check, skip_after, skip_before
 
 
 def test_MatMult() -> None:
@@ -215,28 +215,7 @@ def test_FormattedValue() -> None:
 
 
 def test_formatted_dict_with_format_spec() -> None:
-    tree = ast.Module(
-        body=[
-            ast.Expr(
-                value=ast.JoinedStr(
-                    values=[
-                        ast.FormattedValue(
-                            value=ast.Dict(keys=[], values=[]),
-                            conversion=115,
-                            format_spec=ast.JoinedStr(
-                                values=[ast.Constant(value="'''")]
-                            ),
-                        ),
-                        ast.Constant(value='"""'),
-                    ]
-                )
-            )
-        ],
-        type_ignores=[],
-    )
-    ast.fix_missing_locations(tree)
-
-    assert ast.dump(ast.parse(decompile(tree))) == ast.dump(tree)
+    check("f\"{ {} :'''}\"")
 
 
 def test_Bytes() -> None:
@@ -250,28 +229,7 @@ def test_NameConstant() -> None:
 def test_Starred() -> None:
     check("a, *b = 3")
     check("[a, *b]")
-    tree = ast.Module(
-        body=[
-            ast.Expr(
-                value=ast.Tuple(
-                    elts=[
-                        ast.Starred(
-                            value=ast.Compare(
-                                left=ast.Constant(value=0),
-                                ops=[ast.LtE()],
-                                comparators=[ast.Constant(value=0)],
-                            ),
-                            ctx=ast.Load(),
-                        )
-                    ],
-                    ctx=ast.Load(),
-                )
-            )
-        ],
-        type_ignores=[],
-    )
-    ast.fix_missing_locations(tree)
-    assert ast.dump(ast.parse(decompile(tree))) == ast.dump(tree)
+    check("(*(0 <= 0),)")
 
 
 def test_kwonlyargs() -> None:

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -172,6 +172,12 @@ async def f(x):
     return 3, (await x)
 """
     )
+    check(
+        """
+async def f(x, y, z):
+    return await (x if y else z)
+"""
+    )
 
 
 def test_YieldFrom() -> None:

--- a/tests/test_py3_syntax.py
+++ b/tests/test_py3_syntax.py
@@ -207,6 +207,31 @@ def test_FormattedValue() -> None:
     check('f"{{{a}"')
 
 
+def test_formatted_dict_with_format_spec() -> None:
+    tree = ast.Module(
+        body=[
+            ast.Expr(
+                value=ast.JoinedStr(
+                    values=[
+                        ast.FormattedValue(
+                            value=ast.Dict(keys=[], values=[]),
+                            conversion=115,
+                            format_spec=ast.JoinedStr(
+                                values=[ast.Constant(value="'''")]
+                            ),
+                        ),
+                        ast.Constant(value='"""'),
+                    ]
+                )
+            )
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(tree)
+
+    assert ast.dump(ast.parse(decompile(tree))) == ast.dump(tree)
+
+
 def test_Bytes() -> None:
     check('b"a"')
 


### PR DESCRIPTION
I switched the from ast.unparse to ast_decompiler in pysource-codegen and found several bugs and let codex fix them. 

- fix spacing around formatted dict values
- fix lambda comprehension iterators
- fix multiline match-or patterns
- fix double-starred lambda expressions
- fix lambda spacing for special args
- fix multiline type parameter lists
- fix multiline top-level match-or patterns
- fix multiline match mappings with rest
- fix posonly lambda defaults
- fix multiline match class patterns
- fix starred comparisons
- fix await conditional expressions
- fix lambda formatted values
